### PR TITLE
Update Copyright and Source Code Link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-16 Leonhard Kuboschek, Tom Wiesing, Jinbo Zhang & Rubin Deliallisi
+Copyright (c) 2015-17 Leonhard Kuboschek, Tom Wiesing & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ see [doc/](doc) for minimal developer documentation
 
 ## License
 
-Jay is &copy; 2015-16 Leonhard Kuboschek, Tom Wiesing, Jinbo Zhang & Rubin Deliallisi and licensed under MIT license. See [LICENSE.md](LICENSE.md) for details.
+Jay is &copy; 2015-17 Leonhard Kuboschek, Tom Wiesing & Contributors. Licensed under MIT license. See [LICENSE.md](LICENSE.md) for details.

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -87,7 +87,7 @@
     <footer id="footer">
         <div class="row">
           <div class="col-md-4">
-            <span class="text-muted navbar-left">&copy; 2016 Jay Services Inc.</span>
+            <span class="text-muted navbar-left">&copy; 2015-17 Leonhard Kuboschek, Tom Wiesing &amp; Contributors</span>
           </div>
 
           <div class="col-md-4">
@@ -99,7 +99,7 @@
             -->
             <a href="{% url 'imprint' %}" class="text-muted">Imprint</a>
             <a href="{% url 'privacy' %}" class="text-muted">Privacy&nbsp;Policy</a>
-            <a href="https://github.com/kuboschek/jay/tree/prod" class="text-muted">Source Code</a>
+            <a href="https://github.com/OpenJUB/jay/tree/prod" class="text-muted">Source Code</a>
           </div>
         </div>
     </footer>


### PR DESCRIPTION
This commit updates the copyright year to 2017 and changes the source code link to point to the new repository.