### PR TITLE
Move djangoadmin back to /admin

### DIFF
--- a/jay/restricted.py
+++ b/jay/restricted.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 
 RESTRICTED_WORDS = [
     # MASTER
-    'djangoadmin', 'imprint', 'privacy', 'about', 'help', 'filters', 'login',
+    'admin', 'imprint', 'privacy', 'about', 'help', 'filters', 'login',
     'logout', 'settings',
 
     # filters

--- a/jay/urls.py
+++ b/jay/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     url(r'^$', home, name="home"),
 
     # django admin
-    url(r'^djangoadmin/', include(admin.site.urls)),
+    url(r'^admin/', include(admin.site.urls)),
 
     # Static stuff
     url(r'^imprint/$', TemplateView.as_view(template_name="base/imprint.html"),


### PR DESCRIPTION
This PR moves the django admin page back to the `admin/` url. 